### PR TITLE
fix: register button text

### DIFF
--- a/pages/login/index.page.tsx
+++ b/pages/login/index.page.tsx
@@ -129,7 +129,7 @@ export default function Login() {
 							{text.login}
 						</Link>
 					</div>}
-					<LoginButton>{text.login}</LoginButton>
+					<LoginButton>{!newUser ? text.login : text.register}</LoginButton>
 					<Divider text={text.or} />
 					<GoogleLoginButton>Continue with Google</GoogleLoginButton>
 				</div>


### PR DESCRIPTION
When registering as user, register button didn't changed text from "login" to "register".